### PR TITLE
feature/speech-recognition-language-from-locale

### DIFF
--- a/Vocals/Form1.cs
+++ b/Vocals/Form1.cs
@@ -159,7 +159,7 @@ namespace Vocals {
             richTextBox1.AppendText("Starting Speech Recognition Engine \n");
             RecognizerInfo info = null;
             foreach (RecognizerInfo ri in SpeechRecognitionEngine.InstalledRecognizers()) {
-                if (ri.Culture.Equals(System.Globalization.CultureInfo.CurrentCulture)) {
+                if (ri.Culture.Equals(System.Globalization.CultureInfo.CurrentUICulture)) {
                     richTextBox1.AppendText("Setting VR engine language to " + ri.Culture.DisplayName + "\n");
                     info = ri;
                     break;


### PR DESCRIPTION
https://github.com/Al-th/Vocals/issues/5

Définit la langue à utiliser gràce à la locale du système au lieu de la culture.
Donc depuis ce qui est configuré dans le deuxième onglet du panneau de configuration `Region and Language` au lieu du premier.